### PR TITLE
Right align weather panel and hide footer for new layout

### DIFF
--- a/css/new_index.css
+++ b/css/new_index.css
@@ -19,18 +19,20 @@ body.new-layout .top-panel {
     left: 0;
     right: 0;
     height: 55%;
-    display: flex;
-    padding: 3% 0;
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2.25fr);
+    column-gap: 4rem;
+    padding: 3% 5%;
     box-sizing: border-box;
     border-bottom: 4px solid #000000;
 }
 
 body.new-layout .top-column {
-    flex: 1;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: 0 6%;
+    min-width: 0;
+    padding: 0 2%;
 }
 
 body.new-layout .top-column.top-left {
@@ -39,16 +41,18 @@ body.new-layout .top-column.top-left {
 }
 
 body.new-layout .top-column.top-right {
-    align-items: center;
+    align-items: flex-end;
     border-left: 1px solid #000000;
-    text-align: center;
+    text-align: right;
+    padding-left: 6%;
 }
 
 body.new-layout .top-weather-row {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: flex-end;
     gap: 3rem;
+    flex-wrap: wrap;
     width: 100%;
     margin-bottom: 2rem;
 }
@@ -59,17 +63,18 @@ body.new-layout .top-date {
 }
 
 body.new-layout .top-time {
-    font-size: 14rem;
+    font-size: 12rem;
     font-weight: 700;
     margin-top: 1.5rem;
     line-height: 1;
+    white-space: nowrap;
 }
 
 body.new-layout .top-temperature {
     display: flex;
     align-items: center;
     gap: 2rem;
-    font-size: 12rem;
+    font-size: 10rem;
     font-weight: 700;
     line-height: 1;
 }
@@ -86,7 +91,7 @@ body.new-layout #iconWrapper {
 }
 
 body.new-layout #icon {
-    font-size: 14rem;
+    font-size: 11rem;
 }
 
 body.new-layout .top-temperature #temp {
@@ -107,13 +112,18 @@ body.new-layout .temp-unit span {
 
 body.new-layout .top-description {
     margin-top: 2rem;
-    font-size: 4rem;
+    font-size: 3.5rem;
     font-weight: 600;
-    text-align: center;
+    text-align: right;
 }
 
 body.new-layout #description {
     position: static;
+}
+
+body.new-layout #date,
+body.new-layout #sun {
+    display: none;
 }
 
 body.new-layout #lastUpdate {
@@ -130,4 +140,44 @@ body.new-layout #temp {
 
 body.new-layout .temp-unit {
     min-width: 4rem;
+}
+
+@media (max-width: 900px) {
+    body.new-layout .top-panel {
+        column-gap: 3rem;
+        padding: 4% 5%;
+    }
+
+    body.new-layout .top-time {
+        font-size: 10rem;
+    }
+
+    body.new-layout .top-temperature {
+        font-size: 8.5rem;
+        gap: 1.5rem;
+    }
+
+    body.new-layout #icon {
+        font-size: 9.5rem;
+    }
+}
+
+@media (max-width: 720px) {
+    body.new-layout .top-panel {
+        grid-template-columns: minmax(0, 1fr);
+        row-gap: 3rem;
+        height: auto;
+        padding: 5% 6%;
+    }
+
+    body.new-layout .top-column.top-right {
+        border-left: none;
+        border-top: 1px solid #000000;
+        padding-left: 0;
+        padding-top: 3rem;
+    }
+
+    body.new-layout .top-weather-row {
+        justify-content: flex-end;
+    }
 }


### PR DESCRIPTION
## Summary
- switch the new layout header to a grid with responsive spacing to keep the time and weather sections separated
- scale the icon and temperature typography and allow wrapping so the header remains readable on narrower screens
- right-align the weather column in the new layout and hide the legacy footer date/sun strip

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3f3494e848324acef01c29549dd8e